### PR TITLE
feat(quality): Remove stored bitrate index when quality config is set…

### DIFF
--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -1,0 +1,1 @@
+export const STORAGE_BITRATE_INDEX_NAME = 'meister_bitrateIndex';

--- a/src/js/bottom/BottomBar.js
+++ b/src/js/bottom/BottomBar.js
@@ -10,6 +10,7 @@ import CaptionsButton from './CaptionsButton';
 import SeekBar from './SeekBar';
 import VolumeSlider from './VolumeSlider';
 import BaseElement from '../BaseElement';
+import { STORAGE_BITRATE_INDEX_NAME } from '../Constants';
 
 class BottomBar extends BaseElement {
     constructor(config, meister) {
@@ -65,6 +66,8 @@ class BottomBar extends BaseElement {
         if (!this.config.qualityButton || !this.config.qualityButton.hide) {
             this.qualityButton = new QualityButton(meister, this.config);
             this.bottomRightWrapper.appendChild(this.qualityButton.getNode());
+        } else {
+            localStorage.removeItem(STORAGE_BITRATE_INDEX_NAME);
         }
 
         this.langButton = new LanguageButton(meister);

--- a/src/js/bottom/QualityButton/index.js
+++ b/src/js/bottom/QualityButton/index.js
@@ -2,6 +2,7 @@ import BaseElement from '../../BaseElement';
 
 import { prepareBitrateOption, selectBitrate, doesBitrateIndexExist } from './bitrate';
 import { expandQualityMapping, prepareResolutionMapping, prepareResolutionOption, selectResolution } from './resolution';
+import { STORAGE_BITRATE_INDEX_NAME } from '../../Constants';
 
 const RESOLUTION = 0;
 const BITRATE = 1;
@@ -118,7 +119,7 @@ class QualityButton extends BaseElement {
         }
 
         // parseInt with null will return NaN, just like string with not a numeric value.
-        const savedBitrateIndex = parseInt(localStorage.getItem('meister_bitrateIndex'), 10);
+        const savedBitrateIndex = parseInt(localStorage.getItem(STORAGE_BITRATE_INDEX_NAME), 10);
         const bitrateIndexExists = doesBitrateIndexExist(this.bitrates, savedBitrateIndex);
 
         if (!Number.isNaN(savedBitrateIndex) && bitrateIndexExists) {
@@ -171,7 +172,7 @@ class QualityButton extends BaseElement {
                 bitrateIndex,
             });
 
-            localStorage.setItem('meister_bitrateIndex', bitrateIndex.toString());
+            localStorage.setItem(STORAGE_BITRATE_INDEX_NAME, bitrateIndex.toString());
         }
     }
 }


### PR DESCRIPTION
… to hidden

This prevents the storage variable from setting the quality permanently when it should always take the default (Most of the time thats auto). This is mostly for migration when this has already been set.