### PR TITLE
feat(live): Make live threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ var meisterPlayer = new Meister('#player', {
 meisterPlayer.setItem( ... );
 ```
 
+### liveThreshold *[Number]* (in sec) (default: 35) ###
+
+Determines the range near the live edge which is considered 'live' for practical purposes. By default anything closer than 35 seconds to the live edge is considered 'live' and will not trigger the button to seek to the live edge.
+
+``` JavaScript
+var meisterPlayer = new Meister('#player', {
+    StandardUi: {
+        liveThreshold: 30,
+    }
+});
+
+meisterPlayer.setItem( ... );
+```
+
 ### castButton.hide *[Boolean]* (default: false) ###
 
 Hides the castbutton for chromecast. This usually goes in conjuction with a chromecast plugin.

--- a/src/js/bottom/BottomBar.js
+++ b/src/js/bottom/BottomBar.js
@@ -45,7 +45,7 @@ class BottomBar extends BaseElement {
         this.volumeSlider = new VolumeSlider(meister);
         this.bottomLeftWrapper.appendChild(this.volumeSlider.getNode());
 
-        this.timeDisplay = new TimeDisplay(meister);
+        this.timeDisplay = new TimeDisplay(meister, config);
         this.bottomLeftWrapper.appendChild(this.timeDisplay.getNode());
 
 


### PR DESCRIPTION
Previously the display would consider anything between 35 seconds from
the edge and the actual edge as 'live'. Now 35 seconds is still the
default, but it can be changed if required.